### PR TITLE
Feat: dev 모드에서만 콘텐츠 헤더 내 '읽는 시간'을 표기

### DIFF
--- a/src/lib/components/detail/ContentHeader.tsx
+++ b/src/lib/components/detail/ContentHeader.tsx
@@ -4,6 +4,9 @@ import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import { Post } from '@/data/model/type';
 import styled from 'styled-components';
 
+// @TODO: 추후 별도 파일로 분리
+const isDev =  process.env.NODE_ENV === 'development';
+
 export default function ContentHeader({ post }: { post: Post }) {
   return (
     <StyledRootDiv>
@@ -13,7 +16,7 @@ export default function ContentHeader({ post }: { post: Post }) {
         <CalendarTodayIcon sx={{ fontSize: 20 }} />
         <span>{post.dateString}</span>
       </div>
-      <span>읽는 시간 {post.readingMinutes} 분</span>
+      {isDev && <span>읽는 시간 {post.readingMinutes} 분</span>}
     </StyledRootDiv>
   );
 }


### PR DESCRIPTION
## 콘텐츠 최상단에 읽는 시간 표기법 장단점
- 읽는 시간이 긴 경우 (예시: 16분), 사용자가 콘텐츠에 유입 후 바로 이탈 가능성이 매우 높습니다.
- 시간이 짧다면(예시: 3분 이내) 매우 효율적인 방법이기도 합니다.

## 작업 목적
- 아직 콘텐츠 분량에 대한 논의는 시기상조이다.
- 임시적으로 dev 모드에서만 '읽는 시간'이 출력되어서, 콘텐츠 작성자 측면에서 이점이 있도록 수정했습니다.
  
## Future
추후 기획적 논의를 통해서 
1. '읽는 시간/2' 
2. 5분 미만인 경우만 표기 
등으로 기능 요구사항을 개선할 여지가 있습니다.

이상입니다.
감사합니다.