### PR TITLE
Feat: 수동으로 sitemap.xml 추가

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!--  deskers.io sitemap.xml -->
+
+  <!--  main -->
+  <url>
+    <loc>https://deskers.io</loc>
+    <lastmod>2024-04-19T01:59:34.951Z</lastmod>
+    <changefreq>always</changefreq>
+    <priority>1</priority>
+  </url>
+
+  <!--  about -->
+  <url>
+    <loc>https://deskers.io/about</loc>
+    <lastmod>2024-04-19T01:59:34.951Z</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!--  category: office --> 
+  <!--  @TODO: 페이지에서 제거 된 경우, 해당 블록을 삭제한다. -->
+  <url>
+    <loc>https://deskers.io/office</loc>
+    <lastmod>2024-04-19T01:59:34.951Z</lastmod>
+    <changefreq>always</changefreq>
+    <!--  추후 콘텐츠 추가 시, 1로 상향 -->
+    <priority>0.2</priority>
+  </url>
+
+  <!--  category: life -->
+  <!--  @TODO: 페이지에서 제거 된 경우, 해당 블록을 삭제한다. -->
+  <url>
+    <loc>https://deskers.io/life</loc>
+    <lastmod>2024-04-19T01:59:34.951Z</lastmod>
+    <changefreq>always</changefreq>
+    <!--  추후 콘텐츠 추가 시, 1로 상향 -->
+    <priority>0.2</priority>
+  </url>
+
+  <!--  category: deskterior -->
+  <url>
+    <loc>https://deskers.io/deskterior</loc>
+    <lastmod>2024-04-19T01:59:34.951Z</lastmod>
+    <changefreq>always</changefreq>
+    <!--  추후 콘텐츠 추가 시, 1로 상향 -->
+    <priority>0.2</priority>
+  </url>
+
+  <!--  category: content seo -->
+  <url>
+    <loc>https://deskers.io/deskterior</loc>
+    <lastmod>2024-04-19T01:59:34.951Z</lastmod>
+    <changefreq>always</changefreq>
+    <priority>1</priority>
+  </url>
+</urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -49,7 +49,7 @@
 
   <!--  category: content seo -->
   <url>
-    <loc>https://deskers.io/deskterior</loc>
+    <loc>https://deskers.io/content-seo</loc>
     <lastmod>2024-04-19T01:59:34.951Z</lastmod>
     <changefreq>always</changefreq>
     <priority>1</priority>


### PR DESCRIPTION
## 수동으로 사이트 맵을 작성한 이유
1. 페이지 갯수가 적습니다. (현재 총 5개)
2. 근시일 내 추가적인 페이지가 더 생길 것인가에 대한 의문

## 사이트 맵 작성 시 이슈
1. 사이트 맵 속성 중 `priority` 및 `changefreq`는 무시한다고 구글 SEO 가이드 상 명시 되어 있지만, 다른 검색 엔진을 고려해서 형식상 추가는 했습니다.
2. 카테고리 중, 'desketerior', 'content-seo' 외, 'life', 'office'도 사이트맵에 등록 되있습니다.
추후 'life', 'office' 카테고리가 페이지에서 완전히 삭제되면, 사이트맵에서도 함께 삭제 예정입니다.

## Future
1. (반드시) 사이트 MVP 완성 직후, 사이트맵을 구글에 제출
2. (우선순위 낮음) 페이지 갯수가 30개 이상인 경우, 동적 사이트맵 자동 생성
3. (우선순위 매우 낮음) 페이지 별 priority 및 chagefreq에 대한 기준점 확립

## 참고 자료
- (사이트맵이 필요한가요?) https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview?hl=ko
- (NextJS sitemap 수동 생성) https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
- (사이트맵 프로토콜 문서) https://www.sitemaps.org/protocol.html

이상입니다.
감사합니다.