### PR TITLE
Feat: 카테고리 콘텐츠 목록 레이아웃 개선 및 카테고리 콘텐츠 목록 아이템 레이아웃 개선

### DIFF
--- a/src/lib/components/group/hash-list/Content.tsx
+++ b/src/lib/components/group/hash-list/Content.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Image from 'next/image';
-import { ImageListItem, ImageListItemBar } from '@mui/material';
+import { ImageListItem, ImageListItemBar, Stack } from '@mui/material';
 import Link from 'next/link';
 import { Post } from '@/data/model/type';
 
@@ -11,16 +11,18 @@ type Props = {
 export default function Content({ item }: Props) {
   return (
     <Link href={`/${item?.uri}`}>
-      <ImageListItem style={{ cursor: 'pointer' }} onClick={() => {}}>
-        <Image
-          src={item.thumbnail}
-          alt={item.thumbnail}
-          loading="eager"
-          width={300}
-          height={300}
-          style={{ objectFit: 'cover', width: '100%', height: 300 }}
-        />
-        <ImageListItemBar title={item.title} subtitle={<span>{item.content}</span>} position="below" />
+      <ImageListItem style={{ cursor: 'pointer' }} >
+        <ImageListItemBar title={item.title} subtitle={<span>{item.content}</span>}/>
+          <Stack direction={'row'}>
+            <Image
+              src={item.thumbnail}
+              alt={item.thumbnail}
+              loading="eager"
+              width={300}
+              height={300}
+              style={{ objectFit: 'cover', width: '100%', height: 300 }}
+            />
+          </Stack>
       </ImageListItem>
     </Link>
   );

--- a/src/lib/components/group/hash-list/Content.tsx
+++ b/src/lib/components/group/hash-list/Content.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Image from 'next/image';
-import { ImageListItem, ImageListItemBar, Stack } from '@mui/material';
+import { ImageListItem, ImageListItemBar } from '@mui/material';
 import Link from 'next/link';
 import { Post } from '@/data/model/type';
 
@@ -13,16 +13,14 @@ export default function Content({ item }: Props) {
     <Link href={`/${item?.uri}`}>
       <ImageListItem style={{ cursor: 'pointer' }} >
         <ImageListItemBar title={item.title} subtitle={<span>{removeMDXSyntax(item.content)}</span>}/>
-          <Stack direction={'row'}>
-            <Image
-              src={item.thumbnail}
-              alt={item.thumbnail}
-              loading="eager"
-              width={300}
-              height={300}
-              style={{ objectFit: 'cover', width: '100%', height: 300 }}
-            />
-          </Stack>
+          <Image
+            src={item.thumbnail}
+            alt={item.thumbnail}
+            loading="eager"
+            width={300}
+            height={300}
+            style={{ objectFit: 'cover', width: '100%', height: 300 }}
+          />
       </ImageListItem>
     </Link>
   );

--- a/src/lib/components/group/hash-list/Content.tsx
+++ b/src/lib/components/group/hash-list/Content.tsx
@@ -12,7 +12,7 @@ export default function Content({ item }: Props) {
   return (
     <Link href={`/${item?.uri}`}>
       <ImageListItem style={{ cursor: 'pointer' }} >
-        <ImageListItemBar title={item.title} subtitle={<span>{item.content}</span>}/>
+        <ImageListItemBar title={item.title} subtitle={<span>{removeMDXSyntax(item.content)}</span>}/>
           <Stack direction={'row'}>
             <Image
               src={item.thumbnail}
@@ -26,4 +26,34 @@ export default function Content({ item }: Props) {
       </ImageListItem>
     </Link>
   );
+}
+
+// @TODO: 추후 외부 파일로 분리
+function removeMDXSyntax(str: string) {
+  // 굵은 텍스트, 이탤릭 텍스트 제거
+  str = str.replace(/\*\*(.*?)\*\*/g, '$1'); // 굵은 텍스트
+  str = str.replace(/\*(.*?)\*/g, '$1');     // 이탤릭 텍스트
+
+  // 링크 제거 - 링크 텍스트만 남기고 URL 제거
+  str = str.replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1');
+
+  // 인라인 코드 제거
+  str = str.replace(/`([^`]+)`/g, '$1');
+
+  // 코드 블록 제거
+  str = str.replace(/```[\s\S]*?```/g, '');
+
+  // 헤더 제거
+  str = str.replace(/#+\s*(.*)/g, '$1');
+
+  // 이미지 제거
+  str = str.replace(/!\[[^\]]*\]\([^)]*\)/g, '');
+
+  // <br /> 제거
+  str = str.replace(/<br\s*\/?>/gi, '')
+
+  // 리스트 아이템 제거 ('-' 또는 '*'로 시작)
+  str = str.replace(/^\s*[\-\*]\s+(.*)/gm, '$1');
+
+  return str;
 }

--- a/src/lib/components/group/list/ContentList.tsx
+++ b/src/lib/components/group/list/ContentList.tsx
@@ -22,7 +22,7 @@ export default function ContentList({ posts }: Props) {
   return (
     <StyledRootDiv>
       <section className="container">
-        <ImageList sx={{ height: '100%', gridTemplateColumns: `repeat(auto-fill, minmax(200px, 1fr)) !important` }} gap={12}>
+        <ImageList sx={{ height: '100%', gridTemplateColumns: `repeat(1, minmax(200px, 1fr)) !important` }} gap={12}>
           {posts.map((item, idx) => (
             <Content key={`${idx}`} item={item} />
           ))}


### PR DESCRIPTION
## 목적
유저 사용성 측면에서 가독성 향상

## 개선 사항
1. 콘텐츠 목록 내 아이템을 Row당 1개씩 배치
2. 콘텐츠 목록 내 아이템의 레이아웃 개선
3. 콘텐츠 아이템 부제목에 MDX 문법을 제거한 문자열만 출력하도록 재가공

## 개선 후 사진
- PC
<img width="1920" alt="Screen Shot 2024-04-19 at 2 00 20 PM" src="https://github.com/Poylib/deskers/assets/159125561/30782e3c-c8db-4d27-bcd8-1425c4c171fd">

- Mobile
<img width="351" alt="Screen Shot 2024-04-19 at 2 00 46 PM" src="https://github.com/Poylib/deskers/assets/159125561/3d5aa751-7197-4187-b108-127c441bc3a3">


이상입니다.
감사합니다.